### PR TITLE
Add user-specific cart handling

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -14,7 +14,8 @@ const cartController = async(req,res) => {
         name,
         price,
         image,
-        quantity
+        quantity,
+        userId:req.user._id
     })
 
     await product.save()
@@ -25,7 +26,7 @@ const cartController = async(req,res) => {
 
 const getCartProduct = async(req,res) => {
 
-    const products = await CART.find()
+    const products = await CART.find({userId:req.user._id})
 
     if (!products) {
         return res.status(404).json({message:"No Product Found", status:404, success:false})
@@ -39,7 +40,7 @@ const addUpdateCartProduct = async(req,res) => {
     const{id} = req.body
 
     const updatedCart = await CART.findOneAndUpdate(
-      { id },
+      { id, userId:req.user._id },
       { $inc: { quantity: 1 } },
       { new: true, runValidators: true }
     );
@@ -61,7 +62,7 @@ const deleteUpdateCartProduct = async(req,res) => {
     const{id} = req.body
 
     const updatedCart = await CART.findOneAndUpdate(
-      { id },
+      { id, userId:req.user._id },
       { $inc: { quantity: -1 } },
       { new: true, runValidators: true }
     );
@@ -82,7 +83,7 @@ const deleteProduct = async(req,res) => {
 
     let {id} = req.body
 
-    await CART.findOneAndDelete({id})
+    await CART.findOneAndDelete({id, userId:req.user._id})
 
     return res.status(200).json({message:'Product Deleted Successfully!!', status:200, success:true})
 

--- a/backend/middleware/usermiddleware.js
+++ b/backend/middleware/usermiddleware.js
@@ -26,6 +26,7 @@ const ensureAuthentication = async(req,res,next) => {
     }
 
     if (user.email===decoded.email) {
+        req.user = user
         next()
     }
     

--- a/backend/models/cartSchema.js
+++ b/backend/models/cartSchema.js
@@ -22,6 +22,11 @@ const cart = mongoose.Schema({
     quantity:{
         type:Number,
         required:true
+    },
+    userId:{
+        type: mongoose.Schema.Types.ObjectId,
+        ref:'USER',
+        required:true
     }
 })
 

--- a/backend/routes/cartRoutes.js
+++ b/backend/routes/cartRoutes.js
@@ -5,14 +5,14 @@ const ensureAuthentication = require('../middleware/usermiddleware.js')
 
 const cartRoute = express.Router()
 
-cartRoute.post('/addTocart', cartController)
+cartRoute.post('/addTocart',ensureAuthentication, cartController)
 
 cartRoute.get('/getProduct',ensureAuthentication, getCartProduct)
 
-cartRoute.put('/addUpadteCartProduct', addUpdateCartProduct)
+cartRoute.put('/addUpadteCartProduct', ensureAuthentication, addUpdateCartProduct)
 
-cartRoute.put('/delUpdateCartproduct', deleteUpdateCartProduct)
+cartRoute.put('/delUpdateCartproduct', ensureAuthentication, deleteUpdateCartProduct)
 
-cartRoute.delete('/delCartProduct', deleteProduct)
+cartRoute.delete('/delCartProduct', ensureAuthentication, deleteProduct)
 
 module.exports=cartRoute

--- a/frontend/react-app/src/AddCart.jsx
+++ b/frontend/react-app/src/AddCart.jsx
@@ -33,12 +33,16 @@ const AddCart = () => {
   },[isLoggedIn])
 
   const deleteProduct = async(id) => {
-
+    const token = localStorage.getItem('token')
     if (clothes[id-1].quantity > 1) {
 
       let delCartRes
       try {
-        delCartRes = await axios.put('https://mern-ecomm-dj71.onrender.com/delUpdateCartproduct', clothes[id-1])
+        delCartRes = await axios.put('https://mern-ecomm-dj71.onrender.com/delUpdateCartproduct', clothes[id-1], {
+          headers:{
+            'Authorization': `Bearer ${token}`
+          }
+        })
       } catch (error) {
         console.log(error)
       }
@@ -74,7 +78,7 @@ const AddCart = () => {
 
       let delProductRes
       try {
-        delProductRes = axios.delete('https://mern-ecomm-dj71.onrender.com/delCartProduct', {data:{id}})
+        delProductRes = axios.delete('https://mern-ecomm-dj71.onrender.com/delCartProduct', {data:{id}, headers:{'Authorization': `Bearer ${token}`}})
       } catch (error) {
         console.log(error)
       }
@@ -85,9 +89,15 @@ const AddCart = () => {
 
   const addProduct = async(id) => {
 
+    const token = localStorage.getItem('token')
+
     let addCartRes
       try {
-        addCartRes = await axios.put('https://mern-ecomm-dj71.onrender.com/addUpadteCartProduct', {id})
+        addCartRes = await axios.put('https://mern-ecomm-dj71.onrender.com/addUpadteCartProduct', {id}, {
+          headers:{
+            'Authorization': `Bearer ${token}`
+          }
+        })
 
       } catch (error) {
         console.log(error)

--- a/frontend/react-app/src/Clothing.jsx
+++ b/frontend/react-app/src/Clothing.jsx
@@ -30,9 +30,14 @@ const addcartHandler = async(id) => {
     console.log(error)
   }
 
-  
+
   try {
-    res = await axios.post('https://mern-ecomm-dj71.onrender.com/addTocart',updateres.data.updated)
+    const token = localStorage.getItem('token')
+    res = await axios.post('https://mern-ecomm-dj71.onrender.com/addTocart',updateres.data.updated, {
+      headers:{
+        'Authorization': `Bearer ${token}`
+      }
+    })
   } catch (error) {
     console.log(error)
   }


### PR DESCRIPTION
## Summary
- link cart items to users with `userId`
- expose user in request via auth middleware
- scope cart controller queries by user ID
- protect cart routes
- send auth token in cart requests on frontend

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node backend/server.js` *(fails to start: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_6866ef40312c8326b61fa386d8625edc